### PR TITLE
Include auth server output, create Docker image for auth proxy server

### DIFF
--- a/spotify_auth_proxy/Dockerfile
+++ b/spotify_auth_proxy/Dockerfile
@@ -1,0 +1,29 @@
+# syntax=docker/dockerfile:1
+# FROM golang:1.16
+# WORKDIR /go/src/github.com/conradludgate/terraform-provider-spotify/spotify_auth_proxy
+# RUN go get -u github.com/conradludgate/terraform-provider-spotify/spotify_auth_proxy  
+# COPY app.go .
+# RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o app .
+
+# FROM alpine:latest  
+# RUN apk --no-cache add ca-certificates
+# WORKDIR /root/
+# COPY --from=0 /go/src/github.com/alexellis/href-counter/app .
+# RUN go get -u github.com/conradludgate/terraform-provider-spotify/spotify_auth_proxy
+# # RUN ls
+# WORKDIR $GOPATH/src/github.com/conradludgate/terraform-provider-spotify/spotify_auth_proxy
+# RUN go get -u github.com/conradludgate/terraform-provider-spotify/spotify_auth_proxy
+# RUN go install -v ./...
+# CMD ["spotify_auth_proxy"]  
+
+
+FROM golang:1.16-alpine AS build
+
+WORKDIR /src/
+COPY . /src/
+RUN go get -u github.com/conradludgate/terraform-provider-spotify/spotify_auth_proxy
+RUN CGO_ENABLED=0 go build -o /bin/spotify_auth_proxy
+
+FROM alpine:latest
+COPY --from=build /bin/spotify_auth_proxy /bin/spotify_auth_proxy
+ENTRYPOINT ["/bin/spotify_auth_proxy"]

--- a/spotify_auth_proxy/README.md
+++ b/spotify_auth_proxy/README.md
@@ -1,6 +1,6 @@
 # spotify_auth_proxy
 
-This is an instance of a 'spotify auth server' which acts as an interface between a client and the spotify oauth API.
+This is an instance of a 'Spotify auth server' which acts as an interface between a client and the Spotify oauth API.
 
 ## Installation
 
@@ -12,7 +12,7 @@ go get -u github.com/conradludgate/terraform-provider-spotify/spotify_auth_proxy
 
 ## Usage
 
-First, you need a Spotify client id and secret. Visit https://developer.spotify.com/dashboard/ to create an application.
+First, you need a Spotify client ID and secret. Visit https://developer.spotify.com/dashboard/ to create an application.
 
 If you plan to run this proxy locally, set the redirect URI of the application to `http://localhost:27228/spotify_callback`.
 
@@ -69,8 +69,8 @@ SPOTIFY_CLIENT_SECRET=
 Then, run the following command to start the auth proxy.
 
 ```
-docker run --rm -it -p 27228:27228 --env-file ./.env spotify_auth_proxy
-ey: OK7b1j...
+$ docker run --rm -it -p 27228:27228 --env-file ./.env spotify_auth_proxy
+APIKey: OK7b1j...
 Token:  aoIvJT...
 Auth Server: http://localhost:27228/authorize?token=aoIvJT...
 ```

--- a/spotify_auth_proxy/README.md
+++ b/spotify_auth_proxy/README.md
@@ -33,12 +33,44 @@ spotify_auth_proxy
 It should output the following:
 
 ```
-APIKey: XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
-Token:  YYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYY
+APIKey:       XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+Token:        YYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYY
+Auth Server : ZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ
 ```
 
 Take note of both of these values.
 
-Now, open a browser and navigate to `http://localhost:27228/authorize?token={TOKEN FROM ABOVE}` or approriate for your server location. It should redirect you to spotify to login, and then you will be redirected back to the page where it should confirm that you've authorized correctly.
+Now, open a browser and navigate to the Auth Server URL or the appropriate for your server location. It should redirect you to Spotify to login. After you log in, the auth server will redirect you back to the page where it should confirm that you've authorized correctly.
 
 The API Key is how you will retrieve the access token. The server will handle the token expiration and refreshes for you.
+
+## Docker
+
+Alternatively, you can use the Docker to deploy the Spotify auth proxy locally.
+
+### Build your Docker image
+
+Go to `spotify_auth_proxy` and run the following command to build your Docker image,
+
+```
+docker build . -t spotify_auth_proxy
+```
+
+### Start auth proxy server
+
+First, create a file named `.env` and populate it with the `SPOTIFY_CLIENT_ID`, `SPOTIFY_CLIENT_SECRET` and `SPOTIFY_CLIENT_REDIRECT_URI`. Your file should look similar to the following.
+
+```
+SPOTIFY_CLIENT_REDIRECT_URI=http://localhost:27228/spotify_callback
+SPOTIFY_CLIENT_ID=
+SPOTIFY_CLIENT_SECRET=
+```
+
+Then, run the following command to start the auth proxy.
+
+```
+docker run --rm -it -p 27228:27228 --env-file ./.env spotify_auth_proxy
+ey: OK7b1j...
+Token:  aoIvJT...
+Auth Server: http://localhost:27228/authorize?token=aoIvJT...
+```

--- a/spotify_auth_proxy/main.go
+++ b/spotify_auth_proxy/main.go
@@ -32,6 +32,7 @@ func main() {
 	token = randString(charSet, 64)
 	fmt.Println("APIKey:", apiKey)
 	fmt.Println("Token: ", token)
+	fmt.Printf("Auth Server: http://localhost:27228/authorize?token=%s", token)
 
 	config = &oauth2.Config{
 		ClientID:     os.Getenv("SPOTIFY_CLIENT_ID"),


### PR DESCRIPTION
This PR adds:

1. The auth server URL in the output. This makes it convenient for users to just navigate to the URL after they start proxy server.
2. 
   ```
   $ spotify_auth_proxy
   APIKey:       XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
   Token:        YYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYY
   Auth Server : ZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ
   ```

2. Adds a Dockerfile to generate a Docker image for the auth proxy server. This makes it convenient for users -- they don't need Go on their local machine to start the proxy server. I've pushed a version of this to my personal Docker account - [`im2nguyen/spotify_auth_proxy`](https://hub.docker.com/repository/docker/im2nguyen/spotify_auth_proxy). If you're comfortable @conradludgate, I highly recommend you push an image to your Docker account and update the instructions to use your Docker image by default (instead of users building it by default).

   I've also updated the `README.md` with Docker-specific instructions.

   ```
   $ docker run --rm -it -p 27228:27228 --env-file ./.env conradludgate/spotify_auth_proxy
   APIKey: OK7b1j...
   Token:  aoIvJT...
   Auth Server: http://localhost:27228/authorize?token=aoIvJT...
   ```