### PR TITLE
Added `explicit` filter to spotify_search_track

### DIFF
--- a/data_source_search_track.go
+++ b/data_source_search_track.go
@@ -161,23 +161,19 @@ func dataSourceSearchTrackRead(d *schema.ResourceData, m interface{}) error {
 	var ids []string
 	for _, track := range results.Tracks.Tracks {
 		var artists []interface{}
+		trackData := map[string]interface{}{
+			"id":      track.ID.String(),
+			"name":    track.Name,
+			"artists": artists,
+			"album":   track.Album.ID.String(),
+		}
 		for _, artist := range track.Artists {
 			artists = append(artists, artist.ID.String())
 		}
 		if track.Explicit && d.Get("explicit").(bool) {
-			tracks = append(tracks, map[string]interface{}{
-				"id":      track.ID.String(),
-				"name":    track.Name,
-				"artists": artists,
-				"album":   track.Album.ID.String(),
-			})
+			tracks = append(tracks, trackData)
 		} else if !track.Explicit {
-			tracks = append(tracks, map[string]interface{}{
-				"id":      track.ID.String(),
-				"name":    track.Name,
-				"artists": artists,
-				"album":   track.Album.ID.String(),
-			})
+			tracks = append(tracks, trackData)
 		}
 
 		ids = append(ids, track.ID.String())

--- a/data_source_search_track.go
+++ b/data_source_search_track.go
@@ -96,6 +96,11 @@ func dataSourceSearchTrack() *schema.Resource {
 					},
 				},
 			},
+			"explicit": {
+				Type:     schema.TypeBool,
+				Default:  true,
+				Optional: true,
+			},
 		},
 	}
 }
@@ -159,14 +164,27 @@ func dataSourceSearchTrackRead(d *schema.ResourceData, m interface{}) error {
 		for _, artist := range track.Artists {
 			artists = append(artists, artist.ID.String())
 		}
-		tracks = append(tracks, map[string]interface{}{
-			"id":      track.ID.String(),
-			"name":    track.Name,
-			"artists": artists,
-			"album":   track.Album.ID.String(),
-		})
+		if track.Explicit && d.Get("explicit").(bool) {
+			tracks = append(tracks, map[string]interface{}{
+				"id":      track.ID.String(),
+				"name":    track.Name,
+				"artists": artists,
+				"album":   track.Album.ID.String(),
+			})
+		} else if !track.Explicit {
+			tracks = append(tracks, map[string]interface{}{
+				"id":      track.ID.String(),
+				"name":    track.Name,
+				"artists": artists,
+				"album":   track.Album.ID.String(),
+			})
+		}
 
 		ids = append(ids, track.ID.String())
+	}
+
+	if len(tracks) == 0 {
+		return fmt.Errorf("Could not find track")
 	}
 
 	if *limit == 1 {

--- a/docs/data-sources/search_track.md
+++ b/docs/data-sources/search_track.md
@@ -21,6 +21,7 @@ description: |-
 - **limit** (Number)
 - **name** (String)
 - **year** (String)
+- **explicit** (Bool)
 
 ### Read-only
 


### PR DESCRIPTION
There isn't a way to query the Spotify web API using an explicit filter and apparently no plans to update it: https://github.com/spotify/web-api/issues/296

So I added a query result explicit filter option to the data search. Now you just pass in `explicit = false` (defaults to true) in the `spotify_search_track` data source if you do not want to build a playlist with explicit content.