### PR TITLE
Implement playlist import functionality

### DIFF
--- a/docs/resources/playlist.md
+++ b/docs/resources/playlist.md
@@ -28,4 +28,16 @@ Resource to manage a spotify playlist.
 
 - **snapshot_id** (String)
 
+## Import
 
+A Spotify playlist can be imported using the playlist id, e.g.,
+
+```
+$ terraform import spotify_playlist.example 37i9dQZF1DWVs8I62NcHks
+```
+
+The playlist id is part of the URL used by the Spotify Web Player, e.g.,
+
+```
+https://open.spotify.com/playlist/37i9dQZF1DWVs8I62NcHks
+```

--- a/resource_playlist.go
+++ b/resource_playlist.go
@@ -13,6 +13,9 @@ func resourcePlaylist() *schema.Resource {
 		Read:   resourcePlaylistRead,
 		Update: resourcePlaylistUpdate,
 		Delete: resourcePlaylistDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 
 		Description: "Resource to manage a spotify playlist.",
 


### PR DESCRIPTION
The implementation of Spotify playlist import is straight-forward. Given a playlist id, the playlist is read and imported into the Terraform state.