### PR TITLE
Add spotify_artist data source and add functionality to spotify_album

### DIFF
--- a/docs/data-sources/album.md
+++ b/docs/data-sources/album.md
@@ -24,5 +24,4 @@ description: |-
 - **artists** (List of String) The spotify IDs of the artists
 - **name** (String) The Name of the album
 - **tracks** (List of String) The spotify IDs of the tracks
-
-
+- **track_names** (List of String) The names of the tracks

--- a/docs/data-sources/album.md
+++ b/docs/data-sources/album.md
@@ -23,5 +23,6 @@ description: |-
 
 - **artists** (List of String) The spotify IDs of the artists
 - **name** (String) The Name of the album
+- **tracks** (List of String) The spotify IDs of the tracks
 
 

--- a/docs/data-sources/artist.md
+++ b/docs/data-sources/artist.md
@@ -1,0 +1,41 @@
+---
+page_title: "spotify_artist Data Source - terraform-provider-spotify"
+subcategory: ""
+description: |-
+  
+---
+
+# Data Source `spotify_artist`
+
+
+
+## Example Usage
+
+```terraform
+data "spotify_artist" "overdrive" {
+  url = "https://open.spotify.com/artist/3PALZKWkpwjRvBsRmhlVSS"
+
+  ## Computed
+  # name = "Gunship"
+}
+
+data "spotify_artist" "wolfclub" {
+  spotify_id = "4dCDYKtFTMnKCI9PvEwMQX"
+
+  ## Computed
+  # name = "W O L F C L U B"
+}
+```
+
+## Schema
+
+### Optional
+
+- **spotify_id** (String) Spotify ID of the artist
+- **url** (String) Spotify URL of the artist
+
+### Read-only
+
+- **name** (String) The Name of the artist
+
+

--- a/docs/data-sources/artist.md
+++ b/docs/data-sources/artist.md
@@ -12,7 +12,7 @@ description: |-
 ## Example Usage
 
 ```terraform
-data "spotify_artist" "overdrive" {
+data "spotify_artist" "gunship" {
   url = "https://open.spotify.com/artist/3PALZKWkpwjRvBsRmhlVSS"
 
   ## Computed

--- a/examples/data-sources/spotify_artist/data-source.tf
+++ b/examples/data-sources/spotify_artist/data-source.tf
@@ -1,4 +1,4 @@
-data "spotify_artist" "overdrive" {
+data "spotify_artist" "gunship" {
   url = "https://open.spotify.com/artist/3PALZKWkpwjRvBsRmhlVSS"
 
   ## Computed

--- a/examples/data-sources/spotify_artist/data-source.tf
+++ b/examples/data-sources/spotify_artist/data-source.tf
@@ -1,0 +1,13 @@
+data "spotify_artist" "overdrive" {
+  url = "https://open.spotify.com/artist/3PALZKWkpwjRvBsRmhlVSS"
+
+  ## Computed
+  # name = "Gunship"
+}
+
+data "spotify_artist" "wolfclub" {
+  spotify_id = "4dCDYKtFTMnKCI9PvEwMQX"
+
+  ## Computed
+  # name = "W O L F C L U B"
+}

--- a/spotify/data_source_album.go
+++ b/spotify/data_source_album.go
@@ -39,6 +39,12 @@ func dataSourceAlbum() *schema.Resource {
 				Elem:        &schema.Schema{Type: schema.TypeString},
 				Description: "The spotify IDs of the artists",
 			},
+			"tracks": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Description: "The spotify IDs of the tracks",
+			},
 		},
 	}
 }
@@ -76,6 +82,15 @@ func dataSourceAlbumRead(ctx context.Context, d *schema.ResourceData, m interfac
 	if err := d.Set("artists", artists); err != nil {
 		return diag.FromErr(err)
 	}
+
+	tracks := make([]interface{}, 0, len(album.Tracks.Tracks))
+	for _, track := range album.Tracks.Tracks {
+		tracks = append(tracks, string(track.ID))
+	}
+	if err := d.Set("tracks", tracks); err != nil {
+		return diag.FromErr(err)
+	}
+
 	d.SetId(string(album.ID))
 
 	return nil

--- a/spotify/data_source_album.go
+++ b/spotify/data_source_album.go
@@ -45,6 +45,12 @@ func dataSourceAlbum() *schema.Resource {
 				Elem:        &schema.Schema{Type: schema.TypeString},
 				Description: "The spotify IDs of the tracks",
 			},
+			"track_names": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Description: "The names of the tracks",
+			},
 		},
 	}
 }
@@ -88,6 +94,14 @@ func dataSourceAlbumRead(ctx context.Context, d *schema.ResourceData, m interfac
 		tracks = append(tracks, string(track.ID))
 	}
 	if err := d.Set("tracks", tracks); err != nil {
+		return diag.FromErr(err)
+	}
+
+	track_names := make([]interface{}, 0, len(album.Tracks.Tracks))
+	for _, track := range album.Tracks.Tracks {
+		track_names = append(track_names, string(track.Name))
+	}
+	if err := d.Set("track_names", track_names); err != nil {
 		return diag.FromErr(err)
 	}
 

--- a/spotify/data_source_artist.go
+++ b/spotify/data_source_artist.go
@@ -1,0 +1,68 @@
+package spotify
+
+import (
+	"context"
+	"errors"
+	"net/url"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/zmb3/spotify/v2"
+)
+
+func dataSourceArtist() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceArtistRead,
+
+		Schema: map[string]*schema.Schema{
+			"spotify_id": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				AtLeastOneOf: []string{"spotify_id", "url"},
+				Description:  "Spotify ID of the artist",
+			},
+			"url": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				AtLeastOneOf: []string{"spotify_id", "url"},
+				Description:  "Spotify URL of the artist",
+			},
+			"name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The Name of the artist",
+			},
+		},
+	}
+}
+
+func dataSourceArtistRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	client := m.(*spotify.Client)
+
+	var id spotify.ID
+	if u, ok := d.GetOk("url"); ok {
+		u, err := url.Parse(u.(string))
+		if err != nil {
+			return diag.FromErr(err)
+		}
+		if !strings.HasPrefix(u.Path, "/artist/") {
+			return diag.FromErr(errors.New("URL did not point to a spotify artist"))
+		}
+		id = spotify.ID(strings.TrimPrefix(u.Path, "/artist/"))
+	} else {
+		id = spotify.ID(d.Get("spotify_id").(string))
+	}
+
+	artist, err := client.GetArtist(ctx, id)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	if err := d.Set("name", artist.Name); err != nil {
+		return diag.FromErr(err)
+	}
+	d.SetId(string(artist.ID))
+
+	return nil
+}

--- a/spotify/provider.go
+++ b/spotify/provider.go
@@ -41,6 +41,7 @@ func Provider() *schema.Provider {
 			"spotify_search_track": dataSourceSearchTrack(),
 			"spotify_track":        dataSourceTrack(),
 			"spotify_album":        dataSourceAlbum(),
+			"spotify_artist":       dataSourceArtist(),
 		},
 		ConfigureContextFunc: ClientConfigurer,
 	}


### PR DESCRIPTION
Few additions and improvements,

- New `spotify_artist` data source to query artist ID/URL and retrieve `name`
- Update `spotify_album` to have additional `tracks` and `track_names` data

Example of new data sources in-use: https://github.com/ecliptik/minidisc-playlist